### PR TITLE
feat: Add Kotlin Native targets to all KMP modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,10 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     
     steps:
     - uses: actions/checkout@v4
@@ -29,14 +32,41 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-gradle-
     
-    - name: Grant execute permission for gradlew
+    - name: Cache Kotlin Native
+      uses: actions/cache@v4
+      with:
+        path: ~/.konan
+        key: ${{ runner.os }}-konan-${{ hashFiles('**/gradle.properties', '**/gradle-wrapper.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-konan-
+    
+    - name: Grant execute permission for gradlew (Unix)
+      if: runner.os != 'Windows'
       run: chmod +x modules/gradlew
     
-    - name: Build with Gradle
-      run: cd modules && ./gradlew build
+    - name: Build JVM targets
+      run: cd modules && ./gradlew jvmJar
+      shell: bash
     
-    - name: Run tests
-      run: cd modules && ./gradlew test
+    - name: Build native targets (Linux)
+      if: runner.os == 'Linux'
+      run: cd modules && ./gradlew linuxX64MainKlibrary
+      shell: bash
     
-    - name: Run checks
+    - name: Build native targets (macOS)
+      if: runner.os == 'macOS'
+      run: cd modules && ./gradlew macosX64MainKlibrary macosArm64MainKlibrary
+      shell: bash
+    
+    - name: Build native targets (Windows)
+      if: runner.os == 'Windows'
+      run: cd modules && ./gradlew mingwX64MainKlibrary
+      shell: bash
+    
+    - name: Run JVM tests
+      run: cd modules && ./gradlew jvmTest
+      shell: bash
+    
+    - name: Run JVM checks
       run: cd modules && ./gradlew check
+      shell: bash

--- a/modules/app/build.gradle.kts
+++ b/modules/app/build.gradle.kts
@@ -5,6 +5,11 @@ plugins {
 kotlin {
     jvm()
     
+    linuxX64()
+    macosX64()
+    macosArm64()
+    mingwX64()
+    
     sourceSets {
         val commonMain by getting {
             dependencies {
@@ -24,6 +29,26 @@ kotlin {
         val jvmTest by getting {
             dependencies {
                 implementation(libs.kotest.runner.junit5)
+                implementation(libs.kotest.assertions.core)
+            }
+        }
+        val linuxX64Test by getting {
+            dependencies {
+                implementation(libs.kotest.assertions.core)
+            }
+        }
+        val macosX64Test by getting {
+            dependencies {
+                implementation(libs.kotest.assertions.core)
+            }
+        }
+        val macosArm64Test by getting {
+            dependencies {
+                implementation(libs.kotest.assertions.core)
+            }
+        }
+        val mingwX64Test by getting {
+            dependencies {
                 implementation(libs.kotest.assertions.core)
             }
         }

--- a/modules/build.gradle.kts
+++ b/modules/build.gradle.kts
@@ -24,7 +24,7 @@ tasks.register("test") {
     description = "Runs all tests across all platforms"
     
     // Find all subprojects that have KMP configuration
-    val testableProjects = subprojects
+    val jvmTestTasks = subprojects
         .filter { project -> 
             // Only include projects that have build files
             project.buildFile.exists() 
@@ -33,5 +33,40 @@ tasks.register("test") {
             "${project.path}:jvmTest" 
         }
     
-    dependsOn(testableProjects)
+    val nativeTestTasks = subprojects
+        .filter { project -> 
+            // Only include projects that have build files
+            project.buildFile.exists() 
+        }
+        .flatMap { project ->
+            listOf(
+                "${project.path}:linuxX64Test",
+                "${project.path}:macosX64Test", 
+                "${project.path}:macosArm64Test",
+                "${project.path}:mingwX64Test"
+            )
+        }
+    
+    dependsOn(jvmTestTasks + nativeTestTasks)
+}
+
+// Add native build tasks
+tasks.register("buildNative") {
+    group = "build"
+    description = "Builds native binaries for all platforms"
+    
+    val nativeBuildTasks = subprojects
+        .filter { project -> 
+            project.buildFile.exists() 
+        }
+        .flatMap { project ->
+            listOf(
+                "${project.path}:linuxX64Binaries",
+                "${project.path}:macosX64Binaries", 
+                "${project.path}:macosArm64Binaries",
+                "${project.path}:mingwX64Binaries"
+            )
+        }
+    
+    dependsOn(nativeBuildTasks)
 }

--- a/modules/core/fs/build.gradle.kts
+++ b/modules/core/fs/build.gradle.kts
@@ -6,6 +6,11 @@ plugins {
 kotlin {
     jvm()
     
+    linuxX64()
+    macosX64()
+    macosArm64()
+    mingwX64()
+    
     sourceSets {
         val commonMain by getting {
             dependencies {
@@ -13,6 +18,10 @@ kotlin {
                 implementation(libs.kotlinx.serialization.core)
                 implementation(libs.kotlinx.datetime)
                 implementation(libs.okio)
+            }
+        }
+        val jvmMain by getting {
+            dependencies {
                 implementation(libs.kaml)
             }
         }
@@ -25,6 +34,26 @@ kotlin {
         val jvmTest by getting {
             dependencies {
                 implementation(libs.kotest.runner.junit5)
+            }
+        }
+        val linuxX64Test by getting {
+            dependencies {
+                implementation(libs.kotest.assertions.core)
+            }
+        }
+        val macosX64Test by getting {
+            dependencies {
+                implementation(libs.kotest.assertions.core)
+            }
+        }
+        val macosArm64Test by getting {
+            dependencies {
+                implementation(libs.kotest.assertions.core)
+            }
+        }
+        val mingwX64Test by getting {
+            dependencies {
+                implementation(libs.kotest.assertions.core)
             }
         }
     }

--- a/modules/core/identity/build.gradle.kts
+++ b/modules/core/identity/build.gradle.kts
@@ -5,6 +5,11 @@ plugins {
 kotlin {
     jvm()
     
+    linuxX64()
+    macosX64()
+    macosArm64()
+    mingwX64()
+    
     sourceSets {
         val commonMain by getting {
             dependencies {
@@ -23,6 +28,26 @@ kotlin {
         val jvmTest by getting {
             dependencies {
                 implementation(libs.kotest.runner.junit5)
+            }
+        }
+        val linuxX64Test by getting {
+            dependencies {
+                implementation(libs.kotest.assertions.core)
+            }
+        }
+        val macosX64Test by getting {
+            dependencies {
+                implementation(libs.kotest.assertions.core)
+            }
+        }
+        val macosArm64Test by getting {
+            dependencies {
+                implementation(libs.kotest.assertions.core)
+            }
+        }
+        val mingwX64Test by getting {
+            dependencies {
+                implementation(libs.kotest.assertions.core)
             }
         }
     }

--- a/modules/core/llm/build.gradle.kts
+++ b/modules/core/llm/build.gradle.kts
@@ -5,6 +5,11 @@ plugins {
 kotlin {
     jvm()
     
+    linuxX64()
+    macosX64()
+    macosArm64()
+    mingwX64()
+    
     sourceSets {
         val commonMain by getting {
             dependencies {
@@ -20,6 +25,26 @@ kotlin {
         val jvmTest by getting {
             dependencies {
                 implementation(libs.kotest.runner.junit5)
+                implementation(libs.kotest.assertions.core)
+            }
+        }
+        val linuxX64Test by getting {
+            dependencies {
+                implementation(libs.kotest.assertions.core)
+            }
+        }
+        val macosX64Test by getting {
+            dependencies {
+                implementation(libs.kotest.assertions.core)
+            }
+        }
+        val macosArm64Test by getting {
+            dependencies {
+                implementation(libs.kotest.assertions.core)
+            }
+        }
+        val mingwX64Test by getting {
+            dependencies {
                 implementation(libs.kotest.assertions.core)
             }
         }

--- a/modules/core/model/build.gradle.kts
+++ b/modules/core/model/build.gradle.kts
@@ -6,11 +6,20 @@ plugins {
 kotlin {
     jvm()
     
+    linuxX64()
+    macosX64()
+    macosArm64()
+    mingwX64()
+    
     sourceSets {
         val commonMain by getting {
             dependencies {
                 implementation(libs.kotlinx.serialization.core)
                 implementation(libs.kotlinx.datetime)
+            }
+        }
+        val jvmMain by getting {
+            dependencies {
                 implementation(libs.kaml)
             }
         }
@@ -22,6 +31,26 @@ kotlin {
         val jvmTest by getting {
             dependencies {
                 implementation(libs.kotest.runner.junit5)
+                implementation(libs.kotest.assertions.core)
+            }
+        }
+        val linuxX64Test by getting {
+            dependencies {
+                implementation(libs.kotest.assertions.core)
+            }
+        }
+        val macosX64Test by getting {
+            dependencies {
+                implementation(libs.kotest.assertions.core)
+            }
+        }
+        val macosArm64Test by getting {
+            dependencies {
+                implementation(libs.kotest.assertions.core)
+            }
+        }
+        val mingwX64Test by getting {
+            dependencies {
                 implementation(libs.kotest.assertions.core)
             }
         }

--- a/modules/core/process/build.gradle.kts
+++ b/modules/core/process/build.gradle.kts
@@ -5,6 +5,11 @@ plugins {
 kotlin {
     jvm()
     
+    linuxX64()
+    macosX64()
+    macosArm64()
+    mingwX64()
+    
     sourceSets {
         val commonMain by getting {
             dependencies {
@@ -25,6 +30,26 @@ kotlin {
         val jvmTest by getting {
             dependencies {
                 implementation(libs.kotest.runner.junit5)
+            }
+        }
+        val linuxX64Test by getting {
+            dependencies {
+                implementation(libs.kotest.assertions.core)
+            }
+        }
+        val macosX64Test by getting {
+            dependencies {
+                implementation(libs.kotest.assertions.core)
+            }
+        }
+        val macosArm64Test by getting {
+            dependencies {
+                implementation(libs.kotest.assertions.core)
+            }
+        }
+        val mingwX64Test by getting {
+            dependencies {
+                implementation(libs.kotest.assertions.core)
             }
         }
     }

--- a/modules/core/search/build.gradle.kts
+++ b/modules/core/search/build.gradle.kts
@@ -5,6 +5,11 @@ plugins {
 kotlin {
     jvm()
     
+    linuxX64()
+    macosX64()
+    macosArm64()
+    mingwX64()
+    
     sourceSets {
         val commonMain by getting {
             dependencies {
@@ -23,6 +28,26 @@ kotlin {
                 implementation(libs.kotest.runner.junit5)
                 implementation(libs.kotest.assertions.core)
                 implementation(libs.mockk)
+            }
+        }
+        val linuxX64Test by getting {
+            dependencies {
+                implementation(libs.kotest.assertions.core)
+            }
+        }
+        val macosX64Test by getting {
+            dependencies {
+                implementation(libs.kotest.assertions.core)
+            }
+        }
+        val macosArm64Test by getting {
+            dependencies {
+                implementation(libs.kotest.assertions.core)
+            }
+        }
+        val mingwX64Test by getting {
+            dependencies {
+                implementation(libs.kotest.assertions.core)
             }
         }
     }

--- a/modules/gradle/libs.versions.toml
+++ b/modules/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ kaml = { module = "com.charleskorn.kaml:kaml", version.ref = "kaml" }
 okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
+ktor-client-curl = { module = "io.ktor:ktor-client-curl", version.ref = "ktor" }
 kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
 kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }

--- a/modules/llm-adapter/build.gradle.kts
+++ b/modules/llm-adapter/build.gradle.kts
@@ -6,12 +6,41 @@ plugins {
 kotlin {
     jvm()
     
+    linuxX64()
+    macosX64()
+    macosArm64()
+    mingwX64()
+    
     sourceSets {
         val commonMain by getting {
             dependencies {
                 implementation(libs.ktor.client.core)
-                implementation(libs.ktor.client.cio)
                 implementation(libs.kotlinx.serialization.core)
+            }
+        }
+        val jvmMain by getting {
+            dependencies {
+                implementation(libs.ktor.client.cio)
+            }
+        }
+        val linuxX64Main by getting {
+            dependencies {
+                implementation(libs.ktor.client.curl)
+            }
+        }
+        val macosX64Main by getting {
+            dependencies {
+                implementation(libs.ktor.client.curl)
+            }
+        }
+        val macosArm64Main by getting {
+            dependencies {
+                implementation(libs.ktor.client.curl)
+            }
+        }
+        val mingwX64Main by getting {
+            dependencies {
+                implementation(libs.ktor.client.curl)
             }
         }
         val commonTest by getting {
@@ -22,6 +51,26 @@ kotlin {
         val jvmTest by getting {
             dependencies {
                 implementation(libs.kotest.runner.junit5)
+                implementation(libs.kotest.assertions.core)
+            }
+        }
+        val linuxX64Test by getting {
+            dependencies {
+                implementation(libs.kotest.assertions.core)
+            }
+        }
+        val macosX64Test by getting {
+            dependencies {
+                implementation(libs.kotest.assertions.core)
+            }
+        }
+        val macosArm64Test by getting {
+            dependencies {
+                implementation(libs.kotest.assertions.core)
+            }
+        }
+        val mingwX64Test by getting {
+            dependencies {
                 implementation(libs.kotest.assertions.core)
             }
         }


### PR DESCRIPTION
Add native targets (linuxX64, macosX64, macosArm64, mingwX64) to all modules (they're already KMP, this just ensures that the builds stay KMP)