### PR TITLE
Remove unnecessary check task on jvm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Build and test
 
 on:
   push:
@@ -35,9 +35,6 @@ jobs:
     
     - name: Build and test JVM
       run: cd modules && ./gradlew jvmJar jvmTest
-    
-    - name: Run checks
-      run: cd modules && ./gradlew check
 
   linux-native-build-and-test:
     name: Linux Native Build and Test


### PR DESCRIPTION
Removes the redundant jvm check task from the CI workflow. This is unnecessary as the check task is already run for all targets.