### PR TITLE
build: Add Gradle memory configuration to fix CI failures

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,6 @@
+# JVM memory settings for Gradle daemon
+# Kotlin Native compilation requires more memory for multi-module projects
+org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=1024m
+
+# Suppress warnings about disabled native targets on CI
+kotlin.native.ignoreDisabledTargets=true


### PR DESCRIPTION
Increase gradle memory size to deal with memory pressure on builds.