### PR TITLE
build: Optimize CI build performance with caching and incremental builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
         path: |
           ~/.gradle/caches
           ~/.gradle/wrapper
+          ~/.gradle/kotlin-profile
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
         restore-keys: |
           ${{ runner.os }}-gradle-
@@ -58,6 +59,7 @@ jobs:
         path: |
           ~/.gradle/caches
           ~/.gradle/wrapper
+          ~/.gradle/kotlin-profile
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
         restore-keys: |
           ${{ runner.os }}-gradle-
@@ -107,6 +109,7 @@ jobs:
         path: |
           ~/.gradle/caches
           ~/.gradle/wrapper
+          ~/.gradle/kotlin-profile
         key: ${{ matrix.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
         restore-keys: |
           ${{ matrix.os }}-gradle-
@@ -144,6 +147,7 @@ jobs:
         path: |
           ~/.gradle/caches
           ~/.gradle/wrapper
+          ~/.gradle/kotlin-profile
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
         restore-keys: |
           ${{ runner.os }}-gradle-

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,11 +29,6 @@ subprojects {
         showSkipped = true
         showFailed = true
     }
-
-    tasks.withType<Test>().configureEach {
-        // always run tests
-        outputs.upToDateWhen { false }
-    }
 }
 
 // Add test task that delegates to multiplatform test tasks

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,5 +2,10 @@
 # Kotlin Native compilation requires more memory for multi-module projects
 org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=1024m
 
+# Performance optimizations
+org.gradle.caching=true
+org.gradle.parallel=true
+org.gradle.configuration-cache=true
+
 # Suppress warnings about disabled native targets on CI
 kotlin.native.ignoreDisabledTargets=true


### PR DESCRIPTION
- Enable incremental testing by removing `outputs.upToDateWhen { false }` - tests for unchanged modules will be skipped
- Enable Gradle build cache (`org.gradle.caching=true`) - reuses build outputs across branches, especially beneficial for Kotlin Native compilation
- Enable parallel builds (`org.gradle.parallel=true`) - builds multiple modules simultaneously
- Enable configuration cache (`org.gradle.configuration-cache=true`) - speeds up Gradle configuration phase
- Enhance GitHub Actions caching to include `~/.gradle/kotlin-profile`