### PR TITLE
chore: Update group name to com.duchastel.simon.brainiac

### DIFF
--- a/agents/api/build.gradle.kts
+++ b/agents/api/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
 }
 
-group = "com.brainiac.agents"
+group = "com.duchastel.simon.brainiac.agents"
 
 kotlin {
 

--- a/agents/impl/build.gradle.kts
+++ b/agents/impl/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     alias(libs.plugins.kotest)
 }
 
-group = "com.brainiac.agents"
+group = "com.duchastel.simon.brainiac.agents"
 
 kotlin {
     jvm()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 allprojects {
-    group = "com.brainiac"
+    group = "com.duchastel.simon.brainiac"
     version = "1.0.0"
     
     repositories {

--- a/core/fileaccess/api/build.gradle.kts
+++ b/core/fileaccess/api/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
 }
 
-group = "com.brainiac.core.fileaccess"
+group = "com.duchastel.simon.brainiac.core.fileaccess"
 
 kotlin {
     jvm()

--- a/core/fileaccess/api/src/commonMain/kotlin/AccessLogEntry.kt
+++ b/core/fileaccess/api/src/commonMain/kotlin/AccessLogEntry.kt
@@ -1,4 +1,4 @@
-package com.brainiac.core.fileaccess
+package com.duchastel.simon.brainiac.core.fileaccess
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Contextual

--- a/core/fileaccess/api/src/commonMain/kotlin/FileSystemService.kt
+++ b/core/fileaccess/api/src/commonMain/kotlin/FileSystemService.kt
@@ -1,4 +1,4 @@
-package com.brainiac.core.fileaccess
+package com.duchastel.simon.brainiac.core.fileaccess
 
 import okio.Path
 

--- a/core/fileaccess/api/src/commonMain/kotlin/LTMFile.kt
+++ b/core/fileaccess/api/src/commonMain/kotlin/LTMFile.kt
@@ -1,4 +1,4 @@
-package com.brainiac.core.fileaccess
+package com.duchastel.simon.brainiac.core.fileaccess
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Contextual

--- a/core/fileaccess/api/src/commonMain/kotlin/ShortTermMemory.kt
+++ b/core/fileaccess/api/src/commonMain/kotlin/ShortTermMemory.kt
@@ -1,4 +1,4 @@
-package com.brainiac.core.fileaccess
+package com.duchastel.simon.brainiac.core.fileaccess
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Contextual

--- a/core/fileaccess/impl/build.gradle.kts
+++ b/core/fileaccess/impl/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     alias(libs.plugins.kotest)
 }
 
-group = "com.brainiac.core.fileaccess"
+group = "com.duchastel.simon.brainiac.core.fileaccess"
 
 kotlin {
     jvm()

--- a/core/fileaccess/impl/src/commonMain/kotlin/DefaultFileSystemService.kt
+++ b/core/fileaccess/impl/src/commonMain/kotlin/DefaultFileSystemService.kt
@@ -1,4 +1,4 @@
-package com.brainiac.core.fileaccess
+package com.duchastel.simon.brainiac.core.fileaccess
 
 import okio.Path
 import okio.FileSystem

--- a/core/fileaccess/impl/src/commonTest/kotlin/FileSystemServiceTest.kt
+++ b/core/fileaccess/impl/src/commonTest/kotlin/FileSystemServiceTest.kt
@@ -1,4 +1,4 @@
-package com.brainiac.core.fileaccess
+package com.duchastel.simon.brainiac.core.fileaccess
 
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe

--- a/core/identity/api/build.gradle.kts
+++ b/core/identity/api/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
 }
 
-group = "com.brainiac.core.identity"
+group = "com.duchastel.simon.brainiac.core.identity"
 
 kotlin {
 

--- a/core/identity/api/src/commonMain/kotlin/CoreIdentity.kt
+++ b/core/identity/api/src/commonMain/kotlin/CoreIdentity.kt
@@ -1,4 +1,4 @@
-package com.brainiac.core.identity
+package com.duchastel.simon.brainiac.core.identity
 
 import kotlinx.serialization.Serializable
 

--- a/core/identity/api/src/commonMain/kotlin/CoreIdentityService.kt
+++ b/core/identity/api/src/commonMain/kotlin/CoreIdentityService.kt
@@ -1,4 +1,4 @@
-package com.brainiac.core.identity
+package com.duchastel.simon.brainiac.core.identity
 
 interface CoreIdentityService {
     fun getCoreIdentity(): CoreIdentity

--- a/core/identity/impl/build.gradle.kts
+++ b/core/identity/impl/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     alias(libs.plugins.kotest)
 }
 
-group = "com.brainiac.core.identity"
+group = "com.duchastel.simon.brainiac.core.identity"
 
 kotlin {
     jvm()

--- a/core/identity/impl/src/commonMain/kotlin/DefaultCoreIdentityService.kt
+++ b/core/identity/impl/src/commonMain/kotlin/DefaultCoreIdentityService.kt
@@ -1,6 +1,6 @@
-package com.brainiac.core.identity
+package com.duchastel.simon.brainiac.core.identity
 
-import com.brainiac.core.fileaccess.FileSystemService
+import com.duchastel.simon.brainiac.core.fileaccess.FileSystemService
 import okio.Path
 
 class DefaultCoreIdentityService(

--- a/core/identity/impl/src/commonTest/kotlin/CoreIdentityServiceTest.kt
+++ b/core/identity/impl/src/commonTest/kotlin/CoreIdentityServiceTest.kt
@@ -1,6 +1,6 @@
-package com.brainiac.core.identity
+package com.duchastel.simon.brainiac.core.identity
 
-import com.brainiac.core.fileaccess.FileSystemService
+import com.duchastel.simon.brainiac.core.fileaccess.FileSystemService
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain

--- a/core/process/core-loop/api/build.gradle.kts
+++ b/core/process/core-loop/api/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     alias(libs.plugins.kotlin.multiplatform)
 }
 
-group = "com.brainiac.core.process.coreloop"
+group = "com.duchastel.simon.brainiac.core.process.coreloop"
 
 kotlin {
 

--- a/core/process/core-loop/api/src/commonMain/kotlin/CoreLoopProcess.kt
+++ b/core/process/core-loop/api/src/commonMain/kotlin/CoreLoopProcess.kt
@@ -1,4 +1,4 @@
-package com.brainiac.core.process
+package com.duchastel.simon.brainiac.core.process
 
 interface CoreLoopProcess {
     fun processUserPrompt(userPrompt: String): String

--- a/core/process/core-loop/impl/build.gradle.kts
+++ b/core/process/core-loop/impl/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     alias(libs.plugins.kotest)
 }
 
-group = "com.brainiac.core.process.coreloop"
+group = "com.duchastel.simon.brainiac.core.process.coreloop"
 
 kotlin {
     jvm()

--- a/core/process/core-loop/impl/src/commonMain/kotlin/DefaultCoreLoopProcess.kt
+++ b/core/process/core-loop/impl/src/commonMain/kotlin/DefaultCoreLoopProcess.kt
@@ -1,9 +1,9 @@
-package com.brainiac.core.process
+package com.duchastel.simon.brainiac.core.process
 
-import com.brainiac.core.fileaccess.FileSystemService
-import com.brainiac.core.search.SearchService
-import com.brainiac.core.identity.CoreIdentityService
-import com.brainiac.core.fileaccess.LTMFile
+import com.duchastel.simon.brainiac.core.fileaccess.FileSystemService
+import com.duchastel.simon.brainiac.core.search.SearchService
+import com.duchastel.simon.brainiac.core.identity.CoreIdentityService
+import com.duchastel.simon.brainiac.core.fileaccess.LTMFile
 
 class DefaultCoreLoopProcess(
     private val fileSystemService: FileSystemService,

--- a/core/process/core-loop/impl/src/commonTest/kotlin/CoreLoopProcessTest.kt
+++ b/core/process/core-loop/impl/src/commonTest/kotlin/CoreLoopProcessTest.kt
@@ -1,9 +1,9 @@
-package com.brainiac.core.process
+package com.duchastel.simon.brainiac.core.process
 
-import com.brainiac.core.fileaccess.FileSystemService
-import com.brainiac.core.search.SearchService
-import com.brainiac.core.identity.CoreIdentityService
-import com.brainiac.core.fileaccess.*
+import com.duchastel.simon.brainiac.core.fileaccess.FileSystemService
+import com.duchastel.simon.brainiac.core.search.SearchService
+import com.duchastel.simon.brainiac.core.identity.CoreIdentityService
+import com.duchastel.simon.brainiac.core.fileaccess.*
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain

--- a/core/process/search/api/build.gradle.kts
+++ b/core/process/search/api/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     alias(libs.plugins.kotlin.multiplatform)
 }
 
-group = "com.brainiac.core.process.search"
+group = "com.duchastel.simon.brainiac.core.process.search"
 
 kotlin {
 

--- a/core/process/search/api/src/commonMain/kotlin/SearchService.kt
+++ b/core/process/search/api/src/commonMain/kotlin/SearchService.kt
@@ -1,6 +1,6 @@
-package com.brainiac.core.search
+package com.duchastel.simon.brainiac.core.search
 
-import com.brainiac.core.fileaccess.LTMFile
+import com.duchastel.simon.brainiac.core.fileaccess.LTMFile
 
 interface SearchService {
     fun searchLTM(query: String): List<LTMFile>

--- a/core/process/search/impl/build.gradle.kts
+++ b/core/process/search/impl/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     alias(libs.plugins.kotest)
 }
 
-group = "com.brainiac.core.process.search"
+group = "com.duchastel.simon.brainiac.core.process.search"
 
 kotlin {
     jvm()

--- a/core/process/search/impl/src/commonMain/kotlin/LLMSearchService.kt
+++ b/core/process/search/impl/src/commonMain/kotlin/LLMSearchService.kt
@@ -1,7 +1,7 @@
-package com.brainiac.core.search
+package com.duchastel.simon.brainiac.core.search
 
-import com.brainiac.core.fileaccess.LTMFile
-import com.brainiac.core.fileaccess.FileSystemService
+import com.duchastel.simon.brainiac.core.fileaccess.LTMFile
+import com.duchastel.simon.brainiac.core.fileaccess.FileSystemService
 import okio.Path
 import okio.FileSystem
 

--- a/core/process/search/impl/src/commonTest/kotlin/LLMSearchServiceTest.kt
+++ b/core/process/search/impl/src/commonTest/kotlin/LLMSearchServiceTest.kt
@@ -1,8 +1,8 @@
-package com.brainiac.core.search
+package com.duchastel.simon.brainiac.core.search
 
-import com.brainiac.core.fileaccess.FileSystemService
-import com.brainiac.core.fileaccess.LTMFile
-import com.brainiac.core.fileaccess.LTMFrontmatter
+import com.duchastel.simon.brainiac.core.fileaccess.FileSystemService
+import com.duchastel.simon.brainiac.core.fileaccess.LTMFile
+import com.duchastel.simon.brainiac.core.fileaccess.LTMFrontmatter
 import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.mock


### PR DESCRIPTION
Updated all module group names and package declarations from `com.brainiac.*` to `com.duchastel.simon.brainiac.*`