### PR TITLE
chore: Use kotlin.time instead of datetime

### DIFF
--- a/core/fileaccess/api/build.gradle.kts
+++ b/core/fileaccess/api/build.gradle.kts
@@ -17,7 +17,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 api(libs.kotlinx.serialization.core)
-                api(libs.kotlinx.datetime)
+                
                 api(libs.okio)
             }
         }

--- a/core/fileaccess/api/src/commonMain/kotlin/AccessLogEntry.kt
+++ b/core/fileaccess/api/src/commonMain/kotlin/AccessLogEntry.kt
@@ -1,8 +1,11 @@
+@file:OptIn(ExperimentalTime::class)
+
 package com.brainiac.core.fileaccess
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Contextual
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
+import kotlin.time.ExperimentalTime
 
 @Serializable
 data class AccessLogEntry(

--- a/core/fileaccess/api/src/commonMain/kotlin/LTMFile.kt
+++ b/core/fileaccess/api/src/commonMain/kotlin/LTMFile.kt
@@ -1,8 +1,11 @@
+@file:OptIn(ExperimentalTime::class)
+
 package com.brainiac.core.fileaccess
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Contextual
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
+import kotlin.time.ExperimentalTime
 
 @Serializable
 data class LTMFrontmatter(

--- a/core/fileaccess/api/src/commonMain/kotlin/ShortTermMemory.kt
+++ b/core/fileaccess/api/src/commonMain/kotlin/ShortTermMemory.kt
@@ -1,8 +1,11 @@
+@file:OptIn(ExperimentalTime::class)
+
 package com.brainiac.core.fileaccess
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Contextual
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
+import kotlin.time.ExperimentalTime
 
 @Serializable
 data class StructuredData(

--- a/core/fileaccess/impl/build.gradle.kts
+++ b/core/fileaccess/impl/build.gradle.kts
@@ -20,7 +20,7 @@ kotlin {
             dependencies {
                 api(project(":core:fileaccess:api"))
                 implementation(libs.kotlinx.serialization.core)
-                implementation(libs.kotlinx.datetime)
+                
                 implementation(libs.kotlinx.coroutines.core)
                 implementation(libs.okio)
                 implementation(libs.kaml)
@@ -30,7 +30,7 @@ kotlin {
             dependencies {
                 implementation(libs.kotest.framework.engine)
                 implementation(libs.kotest.assertions.core)
-                implementation(libs.kotlinx.datetime)
+                
             }
         }
         val jvmTest by getting {

--- a/core/fileaccess/impl/src/commonMain/kotlin/DefaultFileSystemService.kt
+++ b/core/fileaccess/impl/src/commonMain/kotlin/DefaultFileSystemService.kt
@@ -1,9 +1,12 @@
+@file:OptIn(ExperimentalTime::class)
+
 package com.brainiac.core.fileaccess
 
 import okio.Path
 import okio.FileSystem
 import com.charleskorn.kaml.Yaml
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
+import kotlin.time.ExperimentalTime
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.contextual
 import kotlinx.serialization.KSerializer
@@ -45,11 +48,12 @@ class DefaultFileSystemService(
     private val stmFilePath: Path,
     private val fileSystem: FileSystem
 ) : FileSystemService {
-    private val yaml = Yaml(
-        serializersModule = SerializersModule {
-            contextual(InstantSerializer)
-        }
-    )
+    private val yaml =
+        Yaml(
+            serializersModule = SerializersModule {
+                contextual(InstantSerializer)
+            }
+        )
     private val locks = mutableMapOf<Path, InMemoryFileLock>()
     private val mutex = Mutex()
 

--- a/core/fileaccess/impl/src/commonTest/kotlin/FileSystemServiceTest.kt
+++ b/core/fileaccess/impl/src/commonTest/kotlin/FileSystemServiceTest.kt
@@ -1,8 +1,11 @@
+@file:OptIn(ExperimentalTime::class)
+
 package com.brainiac.core.fileaccess
 
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
+import kotlin.time.ExperimentalTime
 import okio.FileSystem
 import okio.SYSTEM
 import kotlin.random.Random

--- a/core/process/core-loop/impl/build.gradle.kts
+++ b/core/process/core-loop/impl/build.gradle.kts
@@ -22,7 +22,7 @@ kotlin {
                 implementation(project(":core:fileaccess:impl"))
                 implementation(project(":core:identity:impl"))
                 implementation(project(":core:process:search:impl"))
-                implementation(libs.kotlinx.datetime)
+                
             }
         }
         val commonTest by getting {

--- a/core/process/core-loop/impl/src/commonMain/kotlin/DefaultCoreLoopProcess.kt
+++ b/core/process/core-loop/impl/src/commonMain/kotlin/DefaultCoreLoopProcess.kt
@@ -1,3 +1,5 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
 package com.duchastel.simon.brainiac.core.process
 
 import com.duchastel.simon.brainiac.core.fileaccess.FileSystemService

--- a/core/process/core-loop/impl/src/commonTest/kotlin/CoreLoopProcessTest.kt
+++ b/core/process/core-loop/impl/src/commonTest/kotlin/CoreLoopProcessTest.kt
@@ -14,8 +14,10 @@ import dev.mokkery.every
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verify
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
+import kotlin.time.ExperimentalTime
 
+@OptIn(ExperimentalTime::class)
 class CoreLoopProcessTest : StringSpec({
     
     "should process user prompt with complete flow" {

--- a/core/process/search/impl/build.gradle.kts
+++ b/core/process/search/impl/build.gradle.kts
@@ -27,7 +27,7 @@ kotlin {
             dependencies {
                 implementation(kotlin("test"))
                 implementation(libs.kotest.framework.engine)
-                implementation(libs.kotlinx.datetime)
+                
                 implementation(libs.okio.fakefilesystem)
                 implementation(libs.kotest.assertions.core)
             }

--- a/core/process/search/impl/src/commonTest/kotlin/LLMSearchServiceTest.kt
+++ b/core/process/search/impl/src/commonTest/kotlin/LLMSearchServiceTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
 package com.duchastel.simon.brainiac.core.search
 
 import com.duchastel.simon.brainiac.core.fileaccess.FileSystemService
@@ -11,7 +13,7 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import okio.Path.Companion.toPath
 import okio.fakefilesystem.FakeFileSystem
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ kotlin = "2.2.10"
 ksp = "2.2.10-2.0.2"
 coroutines = "1.7.3"
 kotlinx-serialization = "1.6.0"
-kotlinx-datetime = "0.4.1"
+
 kaml = "0.97.0"
 ktor = "2.3.7"
 okio = "3.16.0"
@@ -15,7 +15,7 @@ test-logger = "4.0.0"
 [libraries]
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinx-serialization" }
-kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
+
 kaml = { module = "com.charleskorn.kaml:kaml", version.ref = "kaml" }
 okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
 okio-fakefilesystem = { module = "com.squareup.okio:okio-fakefilesystem", version.ref = "okio" }


### PR DESCRIPTION
kotlinx.datetime is deprecated in favor of the standard library (kotlin.time)