### PR TITLE
feat: Add Gemini 2.5 Pro model provider implementation

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,9 @@ okio-fakefilesystem = { module = "com.squareup.okio:okio-fakefilesystem", versio
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 ktor-client-curl = { module = "io.ktor:ktor-client-curl", version.ref = "ktor" }
+ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
+ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
+ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
 kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
 kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
 kotest-framework-engine = { module = "io.kotest:kotest-framework-engine", version.ref = "kotest" }

--- a/model-providers/gemini/build.gradle.kts
+++ b/model-providers/gemini/build.gradle.kts
@@ -1,0 +1,55 @@
+plugins {
+    alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.kotest)
+}
+
+group = "com.duchastel.simon.brainiac.agents.gemini"
+
+kotlin {
+    jvm()
+
+    linuxX64()
+    macosX64()
+    macosArm64()
+    mingwX64()
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                implementation(project(":core:model-providers:api"))
+                implementation(libs.ktor.client.core)
+                implementation(libs.ktor.client.content.negotiation)
+                implementation(libs.ktor.serialization.kotlinx.json)
+                implementation(libs.kotlinx.serialization.core)
+                implementation(libs.kotlinx.coroutines.core)
+            }
+        }
+
+        val jvmMain by getting {
+            dependencies {
+                implementation(libs.ktor.client.cio)
+            }
+        }
+
+        val nativeMain by creating {
+            dependsOn(commonMain)
+            dependencies {
+                implementation(libs.ktor.client.curl)
+            }
+        }
+
+        val linuxX64Main by getting { dependsOn(nativeMain) }
+        val macosX64Main by getting { dependsOn(nativeMain) }
+        val macosArm64Main by getting { dependsOn(nativeMain) }
+        val mingwX64Main by getting { dependsOn(nativeMain) }
+    }
+}
+
+tasks.named<Test>("jvmTest") {
+    useJUnitPlatform()
+    filter {
+        isFailOnNoMatchingTests = false
+    }
+}

--- a/model-providers/gemini/src/commonMain/kotlin/com/duchastel/simon/brainiac/agents/gemini/Gemini2_5Pro.kt
+++ b/model-providers/gemini/src/commonMain/kotlin/com/duchastel/simon/brainiac/agents/gemini/Gemini2_5Pro.kt
@@ -1,0 +1,99 @@
+package com.duchastel.simon.brainiac.agents.gemini
+
+import com.duchastel.simon.brainiac.core.process.ModelProvider
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.ktor.serialization.kotlinx.json.*
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * Implementation of ModelProvider for Google's Gemini 2.5 Pro model.
+ *
+ * @param apiKey The Google AI API key for authentication
+ * @param baseUrl The base URL for the Gemini API (defaults to the official endpoint)
+ */
+class Gemini2_5Pro(
+    private val apiKey: String,
+    private val baseUrl: String = "https://generativelanguage.googleapis.com"
+) : ModelProvider {
+
+    private val client = HttpClient {
+        install(ContentNegotiation) {
+            json(Json {
+                ignoreUnknownKeys = true
+                prettyPrint = false
+                isLenient = true
+            })
+        }
+    }
+
+    private val modelEndpoint = "$baseUrl/v1beta/models/gemini-2.5-pro:generateContent"
+
+    override fun process(input: String): String? = runBlocking {
+        try {
+            val request = GeminiRequest(
+                contents = listOf(
+                    Content(
+                        parts = listOf(Part(text = input))
+                    )
+                )
+            )
+
+            val response: HttpResponse = client.post(modelEndpoint) {
+                header("x-goog-api-key", apiKey)
+                contentType(ContentType.Application.Json)
+                setBody(request)
+            }
+
+            if (response.status.isSuccess()) {
+                val geminiResponse: GeminiResponse = response.body()
+                geminiResponse.candidates.firstOrNull()
+                    ?.content?.parts?.firstOrNull()
+                    ?.text
+            } else {
+                println("Gemini API error: ${response.status} - ${response.bodyAsText()}")
+                null
+            }
+        } catch (e: Exception) {
+            println("Error calling Gemini API: ${e.message}")
+            e.printStackTrace()
+            null
+        }
+    }
+}
+
+@Serializable
+internal data class GeminiRequest(
+    val contents: List<Content>
+)
+
+@Serializable
+internal data class Content(
+    val parts: List<Part>,
+    val role: String? = null
+)
+
+@Serializable
+internal data class Part(
+    val text: String
+)
+
+@Serializable
+internal data class GeminiResponse(
+    val candidates: List<Candidate>
+)
+
+@Serializable
+internal data class Candidate(
+    val content: Content,
+    @SerialName("finishReason")
+    val finishReason: String? = null,
+    val index: Int? = null
+)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,7 @@ rootProject.name = "brainiac"
 
 include(
     "model-providers",
+    "model-providers:gemini",
     "core:identity:api",
     "core:identity:impl",
     "core:fileaccess:api",


### PR DESCRIPTION
## Summary
- Implements a new `model-providers:gemini` module with `Gemini2_5Pro` class
- Provides ModelProvider implementation for Google's Gemini 2.5 Pro API
- Uses Ktor HTTP client for cross-platform compatibility
- Adds required Ktor dependencies to libs.versions.toml

## Implementation Details
- **Module**: `model-providers/gemini/`
- **Main Class**: `Gemini2_5Pro` implements `ModelProvider` interface
- **API Endpoint**: `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:generateContent`
- **Dependencies**: Ktor client core, content negotiation, and JSON serialization
- **Platform Support**: JVM (CIO engine), Native targets (Curl engine) - Linux, macOS, Windows

## Changes
- Created new Gradle module at `model-providers/gemini/`
- Added Ktor content negotiation and JSON serialization libraries
- Updated `settings.gradle.kts` to include new module
- Implemented API request/response handling with proper error handling

## Test plan
- [x] Build passes on all KMP targets (JVM, Linux, macOS, Windows)
- [ ] Manual testing with valid Gemini API key
- [ ] Integration testing with model provider interface

🤖 Generated with [Claude Code](https://claude.com/claude-code)