### PR TITLE
ci: Use official Gradle setup action for better caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,16 +20,8 @@ jobs:
         java-version: '17'
         distribution: 'temurin'
 
-    - name: Cache Gradle packages
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.gradle/caches
-          ~/.gradle/wrapper
-          ~/.gradle/kotlin-profile
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-        restore-keys: |
-          ${{ runner.os }}-gradle-
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v4
 
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew


### PR DESCRIPTION
## Summary
- Replace manual Gradle cache configuration with official `gradle/actions/setup-gradle@v4`
- Provides automatic caching of dependencies, wrapper, build cache, and configuration cache
- Follows Gradle's recommended best practices for CI caching

## Test plan
- [x] Verify CI workflow passes
- [x] Confirm cache performance improvements on subsequent runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)